### PR TITLE
Ensure `x-format` evaluates expressions in the correct element context

### DIFF
--- a/src/plugins/format/index.js
+++ b/src/plugins/format/index.js
@@ -1,28 +1,16 @@
 import { create_getter } from "@/utilities/evaluator";
-import { is_nullish, has_modifier } from "@/utilities/utils";
+import { has_modifier } from "@/utilities/utils";
 
-function plugin({ directive, mutateDom }) {
-    directive("format", (el, { modifiers }, { effect, evaluateLater }) => {
-        const cache = new Map;
+function plugin({ directive, evaluateLater, mutateDom }) {
+    directive("format", (el, { modifiers }, { effect }) => {
         const placeholder_regex = /{{(?<expr>.+?)}}/g;
         const is_once = has_modifier(modifiers, "once");
 
         process(el);
 
-        function get_eval_fn(expression) {
-            let getter = cache.get(expression);
-            if (is_nullish(getter)) {
-                getter = create_getter(evaluateLater, expression);
-                cache.set(expression, getter);
-            }
-
-            return getter;
-        }
-
         function update(callback) {
             if (is_once) {
                 mutateDom(() => callback());
-                cache.clear();
             }
             else {
                 effect(() => mutateDom(() => callback()));
@@ -53,7 +41,7 @@ function plugin({ directive, mutateDom }) {
                         fragment.appendChild(document.createTextNode(tokens[i]));
                     }
                     else {
-                        const get_value = get_eval_fn(tokens[i]);
+                        const get_value = create_getter(evaluateLater, node.parentNode, tokens[i]);
                         const text = document.createTextNode("");
 
                         fragment.append(text);
@@ -71,7 +59,7 @@ function plugin({ directive, mutateDom }) {
                 const matches = [...attr.value.matchAll(placeholder_regex)];
                 if (matches.length) {
                     const template = attr.value;
-                    update(() => attr.value = template.replace(placeholder_regex, (_, expr) => get_eval_fn(expr)()));
+                    update(() => attr.value = template.replace(placeholder_regex, (_, expr) => create_getter(evaluateLater, node, expr)()));
                 }
             }
         }

--- a/tests/cypress/e2e/x-format.cy.js
+++ b/tests/cypress/e2e/x-format.cy.js
@@ -24,3 +24,16 @@ test("x-format: attributes", html`
     get("div").should("contain.text", "[Foo,Bar]");
     get("span").should("have.attr", "title").and("eq", "(Foo:Bar)");
 });
+
+test("x-format: context aware", html`
+    <div x-data x-format>
+        <span id="id_1">{{ $el.id }}</span>
+        <span id="id_2">{{ $el.id }}<span id="id_3" title="{{ $el.id }}"><span id="id_4">{{ $el.id }}</span></span></span>
+    </div>
+`, ({ get }) => {
+
+    get("#id_1").should("contain.text", "id_1");
+    get("#id_2").should("contain.text", "id_2id_4");
+    get("#id_4").should("contain.text", "id_4");
+    get("#id_3").should("have.attr", "title").and("eq", "id_3");
+});


### PR DESCRIPTION
Fixes #10

Ensure `x-format` evaluates expressions in the correct element context