### PR TITLE
Enhance `x-router:link` directive to support parent elements

### DIFF
--- a/src/plugins/router/README.md
+++ b/src/plugins/router/README.md
@@ -159,6 +159,19 @@ The router does not automatically intercept all links. Only links with the `x-ro
 inside an `x-router` container are handled by the router. Links should always be specified normally,
 regardless of the selected history mode.
 
+### Applying `x-router:link` to parent elements
+
+You can also apply `x-router:link` to parent elements, such as `<li>`, to enable more flexible markup structures:
+```html
+<li x-router:link :class="{ active: $active }">
+   <a href="/about">About</a>
+</li>
+```
+
+In this case:
+* `x-router:link` will locate the nested `<a>` element within the parent and use its `href` for routing.
+* The `$active` state will correctly reflect whether the nested link's `href` matches the current route.
+
 ## Inline and External templates
 Routes can be defined using either **inline templates** or **external templates**:
 
@@ -195,7 +208,7 @@ Indicates the current active route and contains the following properties:
 ```
 
 ### Magic `$active`
-Returns `true` or `false`, indicating whether a link corresponds to the active route.
+Returns `true` or `false`, indicating whether a `x-router:link` corresponds to the active route.
 
 ```html
 <nav>
@@ -203,6 +216,15 @@ Returns `true` or `false`, indicating whether a link corresponds to the active r
   <a x-router:link href="/about" class="{ link__active: $active }">About</a>
 </nav>
 ```
+
+#### Applying active class to parent element
+
+```html
+<li x-router:link :class="{ active: $active }">
+   <a href="/about">About</a>
+</li>
+```
+The `$active` state will correctly reflect whether the nested link's `href` matches the current route.
 
 ## Route templates
 

--- a/src/plugins/router/history.js
+++ b/src/plugins/router/history.js
@@ -11,7 +11,8 @@ const hash_api = {
         return location;
     },
     resolve(path) {
-        return new URL(path).hash.slice(1) || "/";
+        let url = new URL(path);
+        return url.hash ? url.hash.slice(1) || "/" : url.pathname;
     },
     navigate(path, replace = false) {
         path.indexOf("#") < 0 && (path = "#" + path);

--- a/src/plugins/router/router.js
+++ b/src/plugins/router/router.js
@@ -149,6 +149,11 @@ export default function({ directive, magic, reactive }) {
 
                 cleanup(unsubscribe);
             }
+
+            //
+            // A warning about a non-existing anchor element is printed in the get_anchor_element function.
+            // warn("<a> element not found")
+            //
         }
 
         function process_outlet() {

--- a/src/plugins/router/router.js
+++ b/src/plugins/router/router.js
@@ -126,24 +126,29 @@ export default function({ directive, magic, reactive }) {
         }
 
         function process_link() {
-            const is_blank = (el.getAttribute("target") ?? "").indexOf("_blank") >= 0;
-            const unsubscribe = listen(el, "click", e => {
-                if (e.metaKey
-                    || e.altKey
-                    || e.ctrlKey
-                    || e.shiftKey
-                    || e.defaultPrevented
-                    || e.button > 0
-                    || is_blank) {
-                    return;
-                }
+            let link = get_anchor_element(el);
+            if (link) {
+                el._r_routerlink = link;
 
-                e.preventDefault();
+                const is_blank = (link.getAttribute("target") ?? "").indexOf("_blank") >= 0;
+                const unsubscribe = listen(link, "click", e => {
+                    if (e.metaKey
+                        || e.altKey
+                        || e.ctrlKey
+                        || e.shiftKey
+                        || e.defaultPrevented
+                        || e.button > 0
+                        || is_blank) {
+                        return;
+                    }
 
-                router.navigate(`${ el.pathname }${ el.search }${ el.hash }`);
-            });
+                    e.preventDefault();
 
-            cleanup(unsubscribe);
+                    router.navigate(`${ link.pathname }${ link.search }${ link.hash }`);
+                });
+
+                cleanup(unsubscribe);
+            }
         }
 
         function process_outlet() {
@@ -161,11 +166,59 @@ export default function({ directive, magic, reactive }) {
 
     magic("active", el => {
         const router = closest(el, node => node._r_router)?._r_router;
-
-        if (!is_nullish(router)) {
-            return router.history.resolve(el.href) === router.values.path;
+        if (is_nullish(router)) {
+            warn("No x-router directive found");
+            return false;
         }
 
-        warn("No x-router directive found");
+        //
+        // Create a dependency on router.values
+        //
+        JSON.stringify(router.values);
+
+        const link = is_anchor_element(el) ? el : closest(el, node => node._r_routerlink)?._r_routerlink;
+
+        //
+        // The issue is that the router:link directive is processed later than x-bind,
+        // and if $active is used in x-bind, we won’t find node._r_routerlink.
+        // Therefore, we delay execution and try again.
+        //
+        // <div x-router:link :class="{ active: $active }">
+        //    ...
+        // </div>
+        //
+
+        if (link) {
+            return router.history.resolve(link.href) === router.values.path;
+        }
+
+        if (el._r_routerlink_init) {
+            warn(`x-router:link directive not found`, el);
+        }
+        else {
+            queueMicrotask(() => {
+                el._r_routerlink_init = true;
+                //
+                // Force an upate
+                //
+                router.values.path = router.values.path;
+            });
+        }
+
+        return false;
     });
+}
+
+function is_anchor_element(el) {
+    return el.tagName.toUpperCase() === "A";
+}
+
+function get_anchor_element(el) {
+    if (is_anchor_element(el)) {
+        return el;
+    }
+
+    const links = el.querySelectorAll("a");
+    links.length !== 1 && warn(`Expected exactly one link, but found ${links.length}`);
+    return links[0];
 }


### PR DESCRIPTION
Currently, `x-router:link` works only when applied directly to anchor (`<a>`) elements. However, it would be beneficial to allow `x-router:link` to be placed on parent elements (e.g., `<li>`).

This improvement enables more flexible markup structures, particularly in scenarios where navigation elements require additional styling or behavior based on the active state.


```html
<li x-router:link :class="{ active: $active }">
   <a href="/about">About</a>
</li>
```

* `x-router:link` locate the nested `<a>` element within the parent and use its `href` for routing.
* The `$active` state correctly reflect whether the nested link's href matches the current route.