### PR TITLE
Support for binding `indeterminate` property in `x-bound` directive

### DIFF
--- a/src/plugins/bound/README.md
+++ b/src/plugins/bound/README.md
@@ -212,6 +212,33 @@ The group of `<input>` elements that should function together can utilize the `g
 </div>
 ```
 
+### Binding `input[type="checkbox"]:indeterminate` property
+The `x-bound` directive supports binding the `indeterminate` property of `<input type="checkbox">` elements,
+allowing you to control the checkbox's indeterminate state (a state where the checkbox is neither checked nor unchecked,
+typically represented visually with a dash or similar indicator).
+
+This is useful for scenarios like selecting a subset of items in a list, such as in a table header checkbox:
+```html
+<table>
+  <thead>
+    <tr>
+      <th>
+        <input type="checkbox"
+               &indeterminate="isPartialSelected"
+               &checked="isAllSelected" />
+      </th>
+      <th>Value</th>
+    </tr>
+  </thead>
+  ...
+</table>
+```
+In this example, the `indeterminate` property of the checkbox is bound to the `isPartialSelected` data property.
+When `isPartialSelected` is `true`, the checkbox will be in the indeterminate state.
+
+> [!NOTE]
+> The `indeterminate` binding is one-way. Changes to the indeterminate property in the DOM (e.g., via user interaction or JavaScript) do not update the bound data property.
+
 ### Binding `Alpine` data properties
 
 The directive also supports synchronizing values between two data properties.

--- a/src/plugins/bound/index.js
+++ b/src/plugins/bound/index.js
@@ -23,6 +23,7 @@ const canonical_names = create_map(
     "videoHeight,videoWidth," +
     "naturalHeight,naturalWidth," +
     "clientHeight,clientWidth,offsetHeight,offsetWidth," +
+    "indeterminate," +
     "open," +
     "group");
 
@@ -97,6 +98,10 @@ function plugin({ directive, entangle, evaluateLater, mapAttributes, mutateDom, 
             case "offsetHeight":
             case "offsetWidth":
                 process_dimensions();
+                break;
+
+            case "indeterminate":
+                process_indeterminate();
                 break;
 
             case "open":
@@ -190,6 +195,14 @@ function plugin({ directive, entangle, evaluateLater, mapAttributes, mutateDom, 
             if (is_checkable_input(el)) {
                 effect(update_property);
                 cleanup(listen(el, "change", update_variable));
+                processed = true;
+            }
+        }
+
+        function process_indeterminate() {
+            if (el.type === "checkbox") {
+                is_nullish(get_value()) && update_variable();
+                effect(update_property);
                 processed = true;
             }
         }

--- a/tests/playwright/x-bound.spec.js
+++ b/tests/playwright/x-bound.spec.js
@@ -16,6 +16,51 @@ test.describe("x-bound: checkbox", () => {
         await expect(page.locator("span")).toHaveText("false");
     });
 
+    test("checkbox:indeterminate", async ({ page }) => {
+        await set_html(page, `
+            <div x-data="{ indeterminate: true }">
+                <input type="checkbox" &indeterminate />
+                <button @click="indeterminate = !indeterminate">Clear indeterminate</button>
+                <span x-format>{{ indeterminate }}</span>
+            </div>`);
+
+        await expect(page.locator("span")).toHaveText("true");
+        await page.locator("button").click();
+        await expect(page.locator("span")).toHaveText("false");
+        await page.locator("button").click();
+        await expect(page.locator("span")).toHaveText("true");
+    });
+
+    test("checkbox:indeterminate - initialize from undefined", async ({ page }) => {
+        await set_html(page, `
+            <div x-data="{ indeterminate: undefined }">
+                <input type="checkbox" &indeterminate />
+                <button @click="indeterminate = !indeterminate">Clear indeterminate</button>
+                <span x-format>{{ indeterminate }}</span>
+            </div>`);
+
+        await expect(page.locator("span")).toHaveText("false");
+        await page.locator("button").click();
+        await expect(page.locator("span")).toHaveText("true");
+        await page.locator("button").click();
+        await expect(page.locator("span")).toHaveText("false");
+    });
+
+    test("checkbox:indeterminate - initialize from null", async ({ page }) => {
+        await set_html(page, `
+            <div x-data="{ indeterminate: null }">
+                <input type="checkbox" &indeterminate />
+                <button @click="indeterminate = !indeterminate">Clear indeterminate</button>
+                <span x-format>{{ indeterminate }}</span>
+            </div>`);
+
+        await expect(page.locator("span")).toHaveText("false");
+        await page.locator("button").click();
+        await expect(page.locator("span")).toHaveText("true");
+        await page.locator("button").click();
+        await expect(page.locator("span")).toHaveText("false");
+    });
+
     test("radio", async ({ page }) => {
         await set_html(page, `
             <div x-data="{ checked: true }">


### PR DESCRIPTION
**Example:**
```html
<table>
  <thead>
    <tr>
      <th>
        <input type="checkbox"
               &indeterminate="isPartialSelected"
               &checked="isAllSelected" />
      </th>
      <th>Value</th>
    </tr>
  </thead>
  ...
</table>
```
